### PR TITLE
Fix CI on Windows (#748)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,7 +62,7 @@ jobs:
     - name: Install Python Deps
       if: steps.release.outputs.version == 0
       run: |
-        pip install -U pip setuptools
+        python -m pip install -U pip setuptools
         pip install -e .[test]
 
     - name: Test
@@ -118,7 +118,7 @@ jobs:
     - name: Install Python Deps
       if: steps.release.outputs.version == 0
       run: |
-        pip install -U pip setuptools
+        python -m pip install -U pip setuptools
         pip install -e .[test]
 
     - name: Test


### PR DESCRIPTION
Due to executable file locking `pip install -U pip` doesn't work on
Windows, one has to use `python -m pip install -U pip` instead.